### PR TITLE
Fix wrong launch command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cargo run --bin node purge-chain --dev
 Now you can start the development chain:
 
 ```bash
-cargo run --bin node --dev
+cargo run -p node -- --dev
 ```
 
 ## Connecting to the Node


### PR DESCRIPTION
Not sure if this is what you mean here. `--bin` doesn't accept the extra `--dev` argument, and the client API example didn't work for me with just `cargo run --bin node`.